### PR TITLE
fix: font rendering isn't working

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 [dependencies]
 png = "0.17"
 # faster compilation: remove unnecessary features
-plotters = { version = "0.3", default-features = false, features = ["bitmap_backend", "line_series"] }
+plotters = { version = "0.3", features = ["bitmap_backend", "line_series"] }
 plotters-bitmap = "0.3"
 ringbuffer = "0.8"
 cpal = "0.13"


### PR DESCRIPTION
when [using this crate](https://github.com/phip1611/spectrum-analyzer):

```
thread 'main' panicked at /home/nanai/.cargo/registry/src/index.crates.io-6f17d22bba15001f/plotters-0.3.5/src/style/font/mod.rs:75:9:
The font implementation is unable to draw text
```

panicked from this crate.

---

futher reading: [plotters-rs: Font manipulation features](https://github.com/plotters-rs/plotters#list-of-features)
